### PR TITLE
v 1.7.2 - CI trigger (sight)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: epistack
 Title: Heatmaps of Stack Profiles from Epigenetic Signals
-Version: 1.7.1
+Version: 1.7.2
 Authors@R: c(person("SACI", "Safia", email = "safiasaci1995@gmail.com", role = "aut"),
     person("DEVAILLY", "Guillaume",
         email = "gdevailly@hotmail.com", role = c("cre", "aut")))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,10 @@
 # epistack 1.7.1 (2022-07-21)
++ New parameters in `plotEpistack()`: `rel_widths` and `rel_heights`, 
+to adjust the relative widths and heights of the panels.
++ In `plotEpistack()`, the boxMetric panel is now a bit higher.
++ `plotMetric()` now have a `ylab` parameter, exposed in `plotEpistack()`
+
+# epistack 1.7.1 (2022-07-21)
 + left-most panel in `plotEpistack()` is a bit wider
 + fixed a code typo in vignette
 

--- a/R/plotMetric.R
+++ b/R/plotMetric.R
@@ -10,6 +10,7 @@
 #' @param title Title of the plot.
 #' @param ylim limit of the y axis; format: \code{ylim = c(min, max)}
 #' @param xlab x-axis title
+#' @param ylab y-axis title
 #'
 #' @export
 #'
@@ -23,7 +24,8 @@
 #' plotMetric(SummarizedExperiment::rowRanges(stackepi)$exp)
 #'
 plotMetric <- function(
-    x, trans_func = function(x) x, title = "Metric", ylim = NULL, xlab = NULL
+    x, trans_func = function(x) x, title = "Metric", ylim = NULL, xlab = NULL,
+    ylab = NULL
 ){
     plot(
         x = rev(trans_func(x)),
@@ -36,6 +38,6 @@ plotMetric <- function(
     graphics::box()
     graphics::axis(1)
     graphics::axis(2, at = c(1, length(x)))
-    graphics::title(xlab = xlab)
+    graphics::title(xlab = xlab, ylab = ylab)
     mtext(side = 3, title , line = 0.5, cex = 0.8 * graphics::par()$cex.main)
 }

--- a/man/plotEpistack.Rd
+++ b/man/plotEpistack.Rd
@@ -17,6 +17,7 @@ plotEpistack(
   metric_col = "exp",
   metric_title = "Metric",
   metric_label = "metric",
+  metric_ylab = NULL,
   metric_transfunc = function(x) x,
   bin_palette = colorRampPalette(c("#DF536B", "black", "#61D04F")),
   npix_height = 650,
@@ -25,6 +26,8 @@ plotEpistack(
   low_mar = c(2.5, 0.6, 0.3, 0.6),
   error_type = c("ci95", "sd", "sem"),
   reversed_z_order = FALSE,
+  rel_widths = c(score = 0.35, bin = 0.08, assays = 0.35),
+  rel_heights = c(1, 0.14, 0.3),
   patterns = NULL,
   ...
 )
@@ -62,6 +65,8 @@ such as expression value, peak height, pvalue, fold change, etc.}
 
 \item{metric_label}{label of the leftmost plots.}
 
+\item{metric_ylab}{y axis label of the top left plot.}
+
 \item{metric_transfunc}{a function to transform value of \code{metric_col}
 before plotting. Useful to apply log10 transformation
 (i.e. with \code{trans_func = function(x) log10(x+1)}).}
@@ -91,6 +96,14 @@ or \code{"ci95"} (95\% confidence interval). Default: \code{"ci95"}.}
 
 \item{reversed_z_order}{For the bottom panels: should the z-order of
 the curves be reversed (i.e. first or last bin on top)?}
+
+\item{rel_widths}{A named vector of three elements of relative panel widths:
+\code{score} is the left-most panel, \code{bin} is the optionnal binning panels, and
+\code{assays} are the panels of the stacked-matrices.
+Default to \code{c(score = .35, bin = .08, assays = .35)}}
+
+\item{rel_heights}{A vector of three elements of relative panel heights.
+Default to \code{c(1, .14, .3)}}
 
 \item{patterns}{only if \code{rse} is of class GRanges.
 A character vector of column prefixes

--- a/man/plotMetric.Rd
+++ b/man/plotMetric.Rd
@@ -9,7 +9,8 @@ plotMetric(
   trans_func = function(x) x,
   title = "Metric",
   ylim = NULL,
-  xlab = NULL
+  xlab = NULL,
+  ylab = NULL
 )
 }
 \arguments{
@@ -24,6 +25,8 @@ Useful to apply log10 transformation
 \item{ylim}{limit of the y axis; format: \code{ylim = c(min, max)}}
 
 \item{xlab}{x-axis title}
+
+\item{ylab}{y-axis title}
 }
 \value{
 Display a plot.

--- a/tests/testthat/_snaps/plotEpistack/epistack-tiny-matrix.svg
+++ b/tests/testthat/_snaps/plotEpistack/epistack-tiny-matrix.svg
@@ -60,79 +60,72 @@
 <text x='199.01' y='31.36' text-anchor='middle' style='font-size: 11.52px; font-family: sans;' textLength='31.37px' lengthAdjust='spacingAndGlyphs'>Metric</text>
 </g>
 <defs>
-  <clipPath id='cpNS43MHwzNTQuMzB8NDAyLjg1fDQzMi4yNA=='>
-    <rect x='5.70' y='402.85' width='348.60' height='29.39' />
+  <clipPath id='cpNDMuNzJ8MzU0LjMwfDQzMS4zNnw1NTIuMjQ='>
+    <rect x='43.72' y='431.36' width='310.58' height='120.88' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNS43MHwzNTQuMzB8NDAyLjg1fDQzMi4yNA==)'>
-</g>
-<defs>
-  <clipPath id='cpNDMuNzJ8MzU0LjMwfDQ1OC44NXw1NTIuMjQ='>
-    <rect x='43.72' y='458.85' width='310.58' height='93.39' />
-  </clipPath>
-</defs>
-<g clip-path='url(#cpNDMuNzJ8MzU0LjMwfDQ1OC44NXw1NTIuMjQ=)'>
-<polygon points='141.49,548.52 256.52,548.52 256.52,547.14 141.49,547.14 ' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
-<line x1='141.49' y1='548.08' x2='256.52' y2='548.08' style='stroke-width: 2.25; stroke-linecap: butt;' />
-<line x1='199.01' y1='548.78' x2='199.01' y2='548.52' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
-<line x1='199.01' y1='545.08' x2='199.01' y2='547.14' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
-<line x1='170.25' y1='548.78' x2='227.77' y2='548.78' style='stroke-width: 0.75;' />
-<line x1='170.25' y1='545.08' x2='227.77' y2='545.08' style='stroke-width: 0.75;' />
-<polygon points='141.49,548.52 256.52,548.52 256.52,547.14 141.49,547.14 ' style='stroke-width: 0.75; fill: none;' />
-<circle cx='199.01' cy='462.31' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='493.88' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='529.63' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='530.30' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='535.15' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='536.49' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='540.47' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='541.52' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='541.71' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='541.74' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='541.94' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='542.06' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='542.09' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='542.37' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='542.37' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='542.40' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<g clip-path='url(#cpNDMuNzJ8MzU0LjMwfDQzMS4zNnw1NTIuMjQ=)'>
+<polygon points='141.49,547.43 256.52,547.43 256.52,545.64 141.49,545.64 ' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<line x1='141.49' y1='546.85' x2='256.52' y2='546.85' style='stroke-width: 2.25; stroke-linecap: butt;' />
+<line x1='199.01' y1='547.76' x2='199.01' y2='547.43' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+<line x1='199.01' y1='542.98' x2='199.01' y2='545.64' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+<line x1='170.25' y1='547.76' x2='227.77' y2='547.76' style='stroke-width: 0.75;' />
+<line x1='170.25' y1='542.98' x2='227.77' y2='542.98' style='stroke-width: 0.75;' />
+<polygon points='141.49,547.43 256.52,547.43 256.52,545.64 141.49,545.64 ' style='stroke-width: 0.75; fill: none;' />
+<circle cx='199.01' cy='435.84' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='476.70' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='522.97' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='523.85' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='530.12' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='531.85' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='537.01' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='538.36' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='538.61' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='538.65' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='538.90' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='539.06' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='539.10' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='539.46' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='539.47' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='539.51' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='539.64' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='539.75' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='540.44' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='540.45' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='540.85' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='541.01' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='541.32' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='541.40' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='541.95' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='542.15' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='542.30' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='542.38' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
 <circle cx='199.01' cy='542.50' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='542.59' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='543.12' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='543.13' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='543.44' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='543.56' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='543.80' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='543.86' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='544.29' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='544.44' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='544.56' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='544.62' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='544.72' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='544.77' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='544.91' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='542.57' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='542.75' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
 </g>
 <defs>
-  <clipPath id='cpMC4wMHwzNjAuMDB8NDU2LjAwfDU3Ni4wMA=='>
-    <rect x='0.00' y='456.00' width='360.00' height='120.00' />
+  <clipPath id='cpMC4wMHwzNjAuMDB8NDAwLjAwfDU3Ni4wMA=='>
+    <rect x='0.00' y='400.00' width='360.00' height='176.00' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMC4wMHwzNjAuMDB8NDU2LjAwfDU3Ni4wMA==)'>
-<text transform='translate(27.56,505.55) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='21.56px' lengthAdjust='spacingAndGlyphs'>metric</text>
+<g clip-path='url(#cpMC4wMHwzNjAuMDB8NDAwLjAwfDU3Ni4wMA==)'>
+<text transform='translate(27.56,491.80) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='21.56px' lengthAdjust='spacingAndGlyphs'>metric</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<line x1='43.72' y1='548.95' x2='43.72' y2='463.27' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='548.95' x2='38.97' y2='548.95' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='534.67' x2='38.97' y2='534.67' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='520.39' x2='38.97' y2='520.39' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='506.11' x2='38.97' y2='506.11' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='491.83' x2='38.97' y2='491.83' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='477.55' x2='38.97' y2='477.55' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='463.27' x2='38.97' y2='463.27' style='stroke-width: 0.75;' />
-<text transform='translate(37.07,548.95) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='4.41px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text transform='translate(37.07,520.39) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='13.22px' lengthAdjust='spacingAndGlyphs'>400</text>
-<text transform='translate(37.07,491.83) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='13.22px' lengthAdjust='spacingAndGlyphs'>800</text>
-<text transform='translate(37.07,463.27) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='17.62px' lengthAdjust='spacingAndGlyphs'>1200</text>
-<text x='199.01' y='452.20' text-anchor='middle' style='font-size: 11.52px; font-family: sans;' textLength='31.37px' lengthAdjust='spacingAndGlyphs'>Metric</text>
+<line x1='43.72' y1='547.98' x2='43.72' y2='437.09' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='547.98' x2='38.97' y2='547.98' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='529.50' x2='38.97' y2='529.50' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='511.02' x2='38.97' y2='511.02' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='492.53' x2='38.97' y2='492.53' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='474.05' x2='38.97' y2='474.05' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='455.57' x2='38.97' y2='455.57' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='437.09' x2='38.97' y2='437.09' style='stroke-width: 0.75;' />
+<text transform='translate(37.07,547.98) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='4.41px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text transform='translate(37.07,529.50) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='13.22px' lengthAdjust='spacingAndGlyphs'>200</text>
+<text transform='translate(37.07,492.53) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='13.22px' lengthAdjust='spacingAndGlyphs'>600</text>
+<text transform='translate(37.07,455.57) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='17.62px' lengthAdjust='spacingAndGlyphs'>1000</text>
+<text x='199.01' y='424.71' text-anchor='middle' style='font-size: 11.52px; font-family: sans;' textLength='31.37px' lengthAdjust='spacingAndGlyphs'>Metric</text>
 </g>
 <defs>
   <clipPath id='cpMzY1LjcwfDcxNC4zMHwzOC4wMnwzNzYuMjQ='>

--- a/tests/testthat/_snaps/plotEpistack/plotepistack-granges.svg
+++ b/tests/testthat/_snaps/plotEpistack/plotepistack-granges.svg
@@ -62,86 +62,82 @@
 <text x='199.01' y='31.36' text-anchor='middle' style='font-size: 11.52px; font-family: sans;' textLength='31.37px' lengthAdjust='spacingAndGlyphs'>Metric</text>
 </g>
 <defs>
-  <clipPath id='cpNS43MHwzNTQuMzB8NDAyLjg1fDQzMi4yNA=='>
-    <rect x='5.70' y='402.85' width='348.60' height='29.39' />
+  <clipPath id='cpNDMuNzJ8MzU0LjMwfDQzMS4zNnw1NTIuMjQ='>
+    <rect x='43.72' y='431.36' width='310.58' height='120.88' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNS43MHwzNTQuMzB8NDAyLjg1fDQzMi4yNA==)'>
+<g clip-path='url(#cpNDMuNzJ8MzU0LjMwfDQzMS4zNnw1NTIuMjQ=)'>
+<polygon points='141.49,547.76 256.52,547.76 256.52,523.60 141.49,523.60 ' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<line x1='141.49' y1='546.82' x2='256.52' y2='546.82' style='stroke-width: 2.25; stroke-linecap: butt;' />
+<line x1='199.01' y1='547.76' x2='199.01' y2='547.76' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+<line x1='199.01' y1='489.29' x2='199.01' y2='523.60' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+<line x1='170.25' y1='547.76' x2='227.77' y2='547.76' style='stroke-width: 0.75;' />
+<line x1='170.25' y1='489.29' x2='227.77' y2='489.29' style='stroke-width: 0.75;' />
+<polygon points='141.49,547.76 256.52,547.76 256.52,523.60 141.49,523.60 ' style='stroke-width: 0.75; fill: none;' />
+<circle cx='199.01' cy='435.84' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='442.97' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='459.44' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='460.00' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='464.72' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='466.32' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='472.35' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='474.40' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='474.81' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='474.88' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='475.31' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='475.58' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='475.65' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='476.29' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='476.31' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='476.38' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='476.62' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='476.83' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='478.19' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='478.22' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='479.06' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='479.41' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='480.12' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='480.30' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='481.68' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='482.18' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='482.59' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='482.81' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='483.16' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='483.36' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='483.87' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='484.56' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='485.22' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='486.27' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='486.44' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='486.87' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='487.01' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='487.05' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
 </g>
 <defs>
-  <clipPath id='cpNDMuNzJ8MzU0LjMwfDQ1OC44NXw1NTIuMjQ='>
-    <rect x='43.72' y='458.85' width='310.58' height='93.39' />
+  <clipPath id='cpMC4wMHwzNjAuMDB8NDAwLjAwfDU3Ni4wMA=='>
+    <rect x='0.00' y='400.00' width='360.00' height='176.00' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNDMuNzJ8MzU0LjMwfDQ1OC44NXw1NTIuMjQ=)'>
-<polygon points='141.49,548.78 256.52,548.78 256.52,530.12 141.49,530.12 ' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
-<line x1='141.49' y1='548.05' x2='256.52' y2='548.05' style='stroke-width: 2.25; stroke-linecap: butt;' />
-<line x1='199.01' y1='548.78' x2='199.01' y2='548.78' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
-<line x1='199.01' y1='503.60' x2='199.01' y2='530.12' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
-<line x1='170.25' y1='548.78' x2='227.77' y2='548.78' style='stroke-width: 0.75;' />
-<line x1='170.25' y1='503.60' x2='227.77' y2='503.60' style='stroke-width: 0.75;' />
-<polygon points='141.49,548.78 256.52,548.78 256.52,530.12 141.49,530.12 ' style='stroke-width: 0.75; fill: none;' />
-<circle cx='199.01' cy='462.31' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='467.82' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='480.54' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='480.98' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='484.62' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='485.86' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='490.52' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='492.10' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='492.42' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='492.47' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='492.80' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='493.01' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='493.07' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='493.56' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='493.58' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='493.63' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='493.82' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='493.98' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='495.03' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='495.05' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='495.70' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='495.97' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='496.52' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='496.66' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='497.73' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='498.11' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='498.43' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='498.60' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='498.87' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='499.02' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='499.41' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='499.95' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='500.46' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='501.27' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='501.41' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='501.73' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='501.84' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='501.87' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-</g>
-<defs>
-  <clipPath id='cpMC4wMHwzNjAuMDB8NDU2LjAwfDU3Ni4wMA=='>
-    <rect x='0.00' y='456.00' width='360.00' height='120.00' />
-  </clipPath>
-</defs>
-<g clip-path='url(#cpMC4wMHwzNjAuMDB8NDU2LjAwfDU3Ni4wMA==)'>
-<text transform='translate(27.56,505.55) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='21.56px' lengthAdjust='spacingAndGlyphs'>metric</text>
+<g clip-path='url(#cpMC4wMHwzNjAuMDB8NDAwLjAwfDU3Ni4wMA==)'>
+<text transform='translate(27.56,491.80) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='21.56px' lengthAdjust='spacingAndGlyphs'>metric</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<line x1='43.72' y1='548.78' x2='43.72' y2='464.68' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='548.78' x2='38.97' y2='548.78' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='534.76' x2='38.97' y2='534.76' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='520.75' x2='38.97' y2='520.75' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='506.73' x2='38.97' y2='506.73' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='492.71' x2='38.97' y2='492.71' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='478.69' x2='38.97' y2='478.69' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='464.68' x2='38.97' y2='464.68' style='stroke-width: 0.75;' />
-<text transform='translate(37.07,548.78) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>0.0</text>
-<text transform='translate(37.07,520.75) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>1.0</text>
-<text transform='translate(37.07,492.71) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>2.0</text>
-<text transform='translate(37.07,464.68) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>3.0</text>
-<text x='199.01' y='452.20' text-anchor='middle' style='font-size: 11.52px; font-family: sans;' textLength='31.37px' lengthAdjust='spacingAndGlyphs'>Metric</text>
+<line x1='43.72' y1='547.76' x2='43.72' y2='438.90' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='547.76' x2='38.97' y2='547.76' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='529.62' x2='38.97' y2='529.62' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='511.48' x2='38.97' y2='511.48' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='493.33' x2='38.97' y2='493.33' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='475.19' x2='38.97' y2='475.19' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='457.05' x2='38.97' y2='457.05' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='438.90' x2='38.97' y2='438.90' style='stroke-width: 0.75;' />
+<text transform='translate(37.07,547.76) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text transform='translate(37.07,529.62) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text transform='translate(37.07,511.48) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text transform='translate(37.07,493.33) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>1.5</text>
+<text transform='translate(37.07,475.19) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>2.0</text>
+<text transform='translate(37.07,457.05) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>2.5</text>
+<text transform='translate(37.07,438.90) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>3.0</text>
+<text x='199.01' y='424.71' text-anchor='middle' style='font-size: 11.52px; font-family: sans;' textLength='31.37px' lengthAdjust='spacingAndGlyphs'>Metric</text>
 </g>
 <defs>
   <clipPath id='cpMzY1LjcwfDcxNC4zMHwzOC4wMnwzNzYuMjQ='>

--- a/tests/testthat/_snaps/plotEpistack/plotepistack-log10-tran.svg
+++ b/tests/testthat/_snaps/plotEpistack/plotepistack-log10-tran.svg
@@ -62,86 +62,82 @@
 <text x='199.01' y='31.36' text-anchor='middle' style='font-size: 11.52px; font-family: sans;' textLength='31.37px' lengthAdjust='spacingAndGlyphs'>Metric</text>
 </g>
 <defs>
-  <clipPath id='cpNS43MHwzNTQuMzB8NDAyLjg1fDQzMi4yNA=='>
-    <rect x='5.70' y='402.85' width='348.60' height='29.39' />
+  <clipPath id='cpNDMuNzJ8MzU0LjMwfDQzMS4zNnw1NTIuMjQ='>
+    <rect x='43.72' y='431.36' width='310.58' height='120.88' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNS43MHwzNTQuMzB8NDAyLjg1fDQzMi4yNA==)'>
+<g clip-path='url(#cpNDMuNzJ8MzU0LjMwfDQzMS4zNnw1NTIuMjQ=)'>
+<polygon points='141.49,547.76 256.52,547.76 256.52,523.60 141.49,523.60 ' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<line x1='141.49' y1='546.82' x2='256.52' y2='546.82' style='stroke-width: 2.25; stroke-linecap: butt;' />
+<line x1='199.01' y1='547.76' x2='199.01' y2='547.76' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+<line x1='199.01' y1='489.29' x2='199.01' y2='523.60' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+<line x1='170.25' y1='547.76' x2='227.77' y2='547.76' style='stroke-width: 0.75;' />
+<line x1='170.25' y1='489.29' x2='227.77' y2='489.29' style='stroke-width: 0.75;' />
+<polygon points='141.49,547.76 256.52,547.76 256.52,523.60 141.49,523.60 ' style='stroke-width: 0.75; fill: none;' />
+<circle cx='199.01' cy='435.84' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='442.97' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='459.44' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='460.00' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='464.72' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='466.32' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='472.35' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='474.40' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='474.81' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='474.88' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='475.31' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='475.58' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='475.65' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='476.29' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='476.31' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='476.38' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='476.62' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='476.83' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='478.19' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='478.22' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='479.06' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='479.41' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='480.12' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='480.30' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='481.68' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='482.18' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='482.59' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='482.81' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='483.16' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='483.36' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='483.87' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='484.56' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='485.22' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='486.27' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='486.44' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='486.87' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='487.01' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='487.05' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
 </g>
 <defs>
-  <clipPath id='cpNDMuNzJ8MzU0LjMwfDQ1OC44NXw1NTIuMjQ='>
-    <rect x='43.72' y='458.85' width='310.58' height='93.39' />
+  <clipPath id='cpMC4wMHwzNjAuMDB8NDAwLjAwfDU3Ni4wMA=='>
+    <rect x='0.00' y='400.00' width='360.00' height='176.00' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNDMuNzJ8MzU0LjMwfDQ1OC44NXw1NTIuMjQ=)'>
-<polygon points='141.49,548.78 256.52,548.78 256.52,530.12 141.49,530.12 ' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
-<line x1='141.49' y1='548.05' x2='256.52' y2='548.05' style='stroke-width: 2.25; stroke-linecap: butt;' />
-<line x1='199.01' y1='548.78' x2='199.01' y2='548.78' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
-<line x1='199.01' y1='503.60' x2='199.01' y2='530.12' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
-<line x1='170.25' y1='548.78' x2='227.77' y2='548.78' style='stroke-width: 0.75;' />
-<line x1='170.25' y1='503.60' x2='227.77' y2='503.60' style='stroke-width: 0.75;' />
-<polygon points='141.49,548.78 256.52,548.78 256.52,530.12 141.49,530.12 ' style='stroke-width: 0.75; fill: none;' />
-<circle cx='199.01' cy='462.31' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='467.82' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='480.54' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='480.98' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='484.62' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='485.86' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='490.52' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='492.10' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='492.42' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='492.47' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='492.80' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='493.01' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='493.07' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='493.56' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='493.58' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='493.63' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='493.82' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='493.98' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='495.03' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='495.05' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='495.70' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='495.97' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='496.52' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='496.66' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='497.73' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='498.11' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='498.43' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='498.60' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='498.87' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='499.02' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='499.41' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='499.95' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='500.46' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='501.27' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='501.41' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='501.73' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='501.84' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='501.87' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-</g>
-<defs>
-  <clipPath id='cpMC4wMHwzNjAuMDB8NDU2LjAwfDU3Ni4wMA=='>
-    <rect x='0.00' y='456.00' width='360.00' height='120.00' />
-  </clipPath>
-</defs>
-<g clip-path='url(#cpMC4wMHwzNjAuMDB8NDU2LjAwfDU3Ni4wMA==)'>
-<text transform='translate(27.56,505.55) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='21.56px' lengthAdjust='spacingAndGlyphs'>metric</text>
+<g clip-path='url(#cpMC4wMHwzNjAuMDB8NDAwLjAwfDU3Ni4wMA==)'>
+<text transform='translate(27.56,491.80) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='21.56px' lengthAdjust='spacingAndGlyphs'>metric</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<line x1='43.72' y1='548.78' x2='43.72' y2='464.68' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='548.78' x2='38.97' y2='548.78' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='534.76' x2='38.97' y2='534.76' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='520.75' x2='38.97' y2='520.75' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='506.73' x2='38.97' y2='506.73' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='492.71' x2='38.97' y2='492.71' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='478.69' x2='38.97' y2='478.69' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='464.68' x2='38.97' y2='464.68' style='stroke-width: 0.75;' />
-<text transform='translate(37.07,548.78) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>0.0</text>
-<text transform='translate(37.07,520.75) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>1.0</text>
-<text transform='translate(37.07,492.71) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>2.0</text>
-<text transform='translate(37.07,464.68) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>3.0</text>
-<text x='199.01' y='452.20' text-anchor='middle' style='font-size: 11.52px; font-family: sans;' textLength='31.37px' lengthAdjust='spacingAndGlyphs'>Metric</text>
+<line x1='43.72' y1='547.76' x2='43.72' y2='438.90' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='547.76' x2='38.97' y2='547.76' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='529.62' x2='38.97' y2='529.62' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='511.48' x2='38.97' y2='511.48' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='493.33' x2='38.97' y2='493.33' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='475.19' x2='38.97' y2='475.19' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='457.05' x2='38.97' y2='457.05' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='438.90' x2='38.97' y2='438.90' style='stroke-width: 0.75;' />
+<text transform='translate(37.07,547.76) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text transform='translate(37.07,529.62) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text transform='translate(37.07,511.48) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text transform='translate(37.07,493.33) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>1.5</text>
+<text transform='translate(37.07,475.19) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>2.0</text>
+<text transform='translate(37.07,457.05) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>2.5</text>
+<text transform='translate(37.07,438.90) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>3.0</text>
+<text x='199.01' y='424.71' text-anchor='middle' style='font-size: 11.52px; font-family: sans;' textLength='31.37px' lengthAdjust='spacingAndGlyphs'>Metric</text>
 </g>
 <defs>
   <clipPath id='cpMzY1LjcwfDcxNC4zMHwzOC4wMnwzNzYuMjQ='>

--- a/tests/testthat/_snaps/plotEpistack/plotepistack-main-title.svg
+++ b/tests/testthat/_snaps/plotEpistack/plotepistack-main-title.svg
@@ -62,86 +62,82 @@
 <text x='199.01' y='31.36' text-anchor='middle' style='font-size: 11.52px; font-family: sans;' textLength='31.37px' lengthAdjust='spacingAndGlyphs'>Metric</text>
 </g>
 <defs>
-  <clipPath id='cpNS43MHwzNTQuMzB8NDAyLjg1fDQzMi4yNA=='>
-    <rect x='5.70' y='402.85' width='348.60' height='29.39' />
+  <clipPath id='cpNDMuNzJ8MzU0LjMwfDQzMS4zNnw1NTIuMjQ='>
+    <rect x='43.72' y='431.36' width='310.58' height='120.88' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNS43MHwzNTQuMzB8NDAyLjg1fDQzMi4yNA==)'>
+<g clip-path='url(#cpNDMuNzJ8MzU0LjMwfDQzMS4zNnw1NTIuMjQ=)'>
+<polygon points='141.49,547.76 256.52,547.76 256.52,523.60 141.49,523.60 ' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<line x1='141.49' y1='546.82' x2='256.52' y2='546.82' style='stroke-width: 2.25; stroke-linecap: butt;' />
+<line x1='199.01' y1='547.76' x2='199.01' y2='547.76' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+<line x1='199.01' y1='489.29' x2='199.01' y2='523.60' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+<line x1='170.25' y1='547.76' x2='227.77' y2='547.76' style='stroke-width: 0.75;' />
+<line x1='170.25' y1='489.29' x2='227.77' y2='489.29' style='stroke-width: 0.75;' />
+<polygon points='141.49,547.76 256.52,547.76 256.52,523.60 141.49,523.60 ' style='stroke-width: 0.75; fill: none;' />
+<circle cx='199.01' cy='435.84' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='442.97' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='459.44' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='460.00' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='464.72' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='466.32' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='472.35' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='474.40' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='474.81' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='474.88' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='475.31' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='475.58' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='475.65' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='476.29' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='476.31' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='476.38' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='476.62' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='476.83' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='478.19' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='478.22' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='479.06' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='479.41' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='480.12' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='480.30' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='481.68' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='482.18' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='482.59' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='482.81' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='483.16' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='483.36' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='483.87' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='484.56' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='485.22' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='486.27' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='486.44' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='486.87' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='487.01' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='199.01' cy='487.05' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
 </g>
 <defs>
-  <clipPath id='cpNDMuNzJ8MzU0LjMwfDQ1OC44NXw1NTIuMjQ='>
-    <rect x='43.72' y='458.85' width='310.58' height='93.39' />
+  <clipPath id='cpMC4wMHwzNjAuMDB8NDAwLjAwfDU3Ni4wMA=='>
+    <rect x='0.00' y='400.00' width='360.00' height='176.00' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNDMuNzJ8MzU0LjMwfDQ1OC44NXw1NTIuMjQ=)'>
-<polygon points='141.49,548.78 256.52,548.78 256.52,530.12 141.49,530.12 ' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
-<line x1='141.49' y1='548.05' x2='256.52' y2='548.05' style='stroke-width: 2.25; stroke-linecap: butt;' />
-<line x1='199.01' y1='548.78' x2='199.01' y2='548.78' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
-<line x1='199.01' y1='503.60' x2='199.01' y2='530.12' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
-<line x1='170.25' y1='548.78' x2='227.77' y2='548.78' style='stroke-width: 0.75;' />
-<line x1='170.25' y1='503.60' x2='227.77' y2='503.60' style='stroke-width: 0.75;' />
-<polygon points='141.49,548.78 256.52,548.78 256.52,530.12 141.49,530.12 ' style='stroke-width: 0.75; fill: none;' />
-<circle cx='199.01' cy='462.31' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='467.82' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='480.54' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='480.98' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='484.62' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='485.86' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='490.52' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='492.10' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='492.42' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='492.47' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='492.80' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='493.01' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='493.07' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='493.56' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='493.58' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='493.63' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='493.82' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='493.98' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='495.03' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='495.05' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='495.70' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='495.97' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='496.52' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='496.66' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='497.73' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='498.11' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='498.43' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='498.60' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='498.87' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='499.02' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='499.41' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='499.95' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='500.46' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='501.27' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='501.41' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='501.73' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='501.84' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='199.01' cy='501.87' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-</g>
-<defs>
-  <clipPath id='cpMC4wMHwzNjAuMDB8NDU2LjAwfDU3Ni4wMA=='>
-    <rect x='0.00' y='456.00' width='360.00' height='120.00' />
-  </clipPath>
-</defs>
-<g clip-path='url(#cpMC4wMHwzNjAuMDB8NDU2LjAwfDU3Ni4wMA==)'>
-<text transform='translate(27.56,505.55) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='21.56px' lengthAdjust='spacingAndGlyphs'>metric</text>
+<g clip-path='url(#cpMC4wMHwzNjAuMDB8NDAwLjAwfDU3Ni4wMA==)'>
+<text transform='translate(27.56,491.80) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='21.56px' lengthAdjust='spacingAndGlyphs'>metric</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<line x1='43.72' y1='548.78' x2='43.72' y2='464.68' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='548.78' x2='38.97' y2='548.78' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='534.76' x2='38.97' y2='534.76' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='520.75' x2='38.97' y2='520.75' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='506.73' x2='38.97' y2='506.73' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='492.71' x2='38.97' y2='492.71' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='478.69' x2='38.97' y2='478.69' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='464.68' x2='38.97' y2='464.68' style='stroke-width: 0.75;' />
-<text transform='translate(37.07,548.78) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>0.0</text>
-<text transform='translate(37.07,520.75) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>1.0</text>
-<text transform='translate(37.07,492.71) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>2.0</text>
-<text transform='translate(37.07,464.68) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>3.0</text>
-<text x='199.01' y='452.20' text-anchor='middle' style='font-size: 11.52px; font-family: sans;' textLength='31.37px' lengthAdjust='spacingAndGlyphs'>Metric</text>
+<line x1='43.72' y1='547.76' x2='43.72' y2='438.90' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='547.76' x2='38.97' y2='547.76' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='529.62' x2='38.97' y2='529.62' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='511.48' x2='38.97' y2='511.48' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='493.33' x2='38.97' y2='493.33' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='475.19' x2='38.97' y2='475.19' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='457.05' x2='38.97' y2='457.05' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='438.90' x2='38.97' y2='438.90' style='stroke-width: 0.75;' />
+<text transform='translate(37.07,547.76) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text transform='translate(37.07,529.62) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text transform='translate(37.07,511.48) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text transform='translate(37.07,493.33) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>1.5</text>
+<text transform='translate(37.07,475.19) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>2.0</text>
+<text transform='translate(37.07,457.05) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>2.5</text>
+<text transform='translate(37.07,438.90) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>3.0</text>
+<text x='199.01' y='424.71' text-anchor='middle' style='font-size: 11.52px; font-family: sans;' textLength='31.37px' lengthAdjust='spacingAndGlyphs'>Metric</text>
 </g>
 <defs>
   <clipPath id='cpMzY1LjcwfDcxNC4zMHwzOC4wMnwzNzYuMjQ='>

--- a/tests/testthat/_snaps/plotEpistack/plotepistack-reversed-z-order.svg
+++ b/tests/testthat/_snaps/plotEpistack/plotepistack-reversed-z-order.svg
@@ -62,63 +62,56 @@
 <text x='180.55' y='31.36' text-anchor='middle' style='font-size: 11.52px; font-family: sans;' textLength='31.37px' lengthAdjust='spacingAndGlyphs'>Metric</text>
 </g>
 <defs>
-  <clipPath id='cpNS43MHwzMTcuMzd8NDAyLjg1fDQzMi4yNA=='>
-    <rect x='5.70' y='402.85' width='311.67' height='29.39' />
+  <clipPath id='cpNDMuNzJ8MzkxLjIyfDQzMS4zNnw1NTIuMjQ='>
+    <rect x='43.72' y='431.36' width='347.50' height='120.88' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNS43MHwzMTcuMzd8NDAyLjg1fDQzMi4yNA==)'>
+<g clip-path='url(#cpNDMuNzJ8MzkxLjIyfDQzMS4zNnw1NTIuMjQ=)'>
+<polygon points='63.02,508.26 114.51,508.26 114.51,486.66 63.02,486.66 ' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<line x1='63.02' y1='500.47' x2='114.51' y2='500.47' style='stroke-width: 2.25; stroke-linecap: butt;' />
+<line x1='88.76' y1='515.34' x2='88.76' y2='508.26' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+<line x1='88.76' y1='459.44' x2='88.76' y2='486.66' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+<line x1='75.89' y1='515.34' x2='101.64' y2='515.34' style='stroke-width: 0.75;' />
+<line x1='75.89' y1='459.44' x2='101.64' y2='459.44' style='stroke-width: 0.75;' />
+<polygon points='63.02,508.26 114.51,508.26 114.51,486.66 63.02,486.66 ' style='stroke-width: 0.75; fill: none;' />
+<circle cx='88.76' cy='435.84' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='88.76' cy='442.97' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<polygon points='127.38,538.76 178.86,538.76 178.86,523.60 127.38,523.60 ' style='stroke-width: 0.75; stroke: none; fill: #6F2935;' />
+<line x1='127.38' y1='531.39' x2='178.86' y2='531.39' style='stroke-width: 2.25; stroke-linecap: butt;' />
+<line x1='153.12' y1='543.41' x2='153.12' y2='538.76' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+<line x1='153.12' y1='515.52' x2='153.12' y2='523.60' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+<line x1='140.25' y1='543.41' x2='165.99' y2='543.41' style='stroke-width: 0.75;' />
+<line x1='140.25' y1='515.52' x2='165.99' y2='515.52' style='stroke-width: 0.75;' />
+<polygon points='127.38,538.76 178.86,538.76 178.86,523.60 127.38,523.60 ' style='stroke-width: 0.75; fill: none;' />
+<polygon points='191.73,547.41 243.21,547.41 243.21,545.74 191.73,545.74 ' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<line x1='191.73' y1='546.82' x2='243.21' y2='546.82' style='stroke-width: 2.25; stroke-linecap: butt;' />
+<line x1='217.47' y1='547.76' x2='217.47' y2='547.41' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+<line x1='217.47' y1='543.58' x2='217.47' y2='545.74' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+<line x1='204.60' y1='547.76' x2='230.34' y2='547.76' style='stroke-width: 0.75;' />
+<line x1='204.60' y1='543.58' x2='230.34' y2='543.58' style='stroke-width: 0.75;' />
+<polygon points='191.73,547.41 243.21,547.41 243.21,545.74 191.73,545.74 ' style='stroke-width: 0.75; fill: none;' />
+<polygon points='256.08,547.76 307.56,547.76 307.56,547.76 256.08,547.76 ' style='stroke-width: 0.75; stroke: none; fill: #306827;' />
+<line x1='256.08' y1='547.76' x2='307.56' y2='547.76' style='stroke-width: 2.25; stroke-linecap: butt;' />
+<line x1='281.82' y1='547.76' x2='281.82' y2='547.76' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+<line x1='281.82' y1='547.76' x2='281.82' y2='547.76' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+<line x1='268.95' y1='547.76' x2='294.69' y2='547.76' style='stroke-width: 0.75;' />
+<line x1='268.95' y1='547.76' x2='294.69' y2='547.76' style='stroke-width: 0.75;' />
+<polygon points='256.08,547.76 307.56,547.76 307.56,547.76 256.08,547.76 ' style='stroke-width: 0.75; fill: none;' />
+<polygon points='320.43,547.76 371.91,547.76 371.91,547.76 320.43,547.76 ' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<line x1='320.43' y1='547.76' x2='371.91' y2='547.76' style='stroke-width: 2.25; stroke-linecap: butt;' />
+<line x1='346.17' y1='547.76' x2='346.17' y2='547.76' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+<line x1='346.17' y1='547.76' x2='346.17' y2='547.76' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+<line x1='333.30' y1='547.76' x2='359.04' y2='547.76' style='stroke-width: 0.75;' />
+<line x1='333.30' y1='547.76' x2='359.04' y2='547.76' style='stroke-width: 0.75;' />
+<polygon points='320.43,547.76 371.91,547.76 371.91,547.76 320.43,547.76 ' style='stroke-width: 0.75; fill: none;' />
 </g>
 <defs>
-  <clipPath id='cpNDMuNzJ8MzkxLjIyfDQ1OC44NXw1NTIuMjQ='>
-    <rect x='43.72' y='458.85' width='347.50' height='93.39' />
+  <clipPath id='cpMC4wMHwzOTYuOTJ8NDAwLjAwfDU3Ni4wMA=='>
+    <rect x='0.000000000000040' y='400.00' width='396.92' height='176.00' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNDMuNzJ8MzkxLjIyfDQ1OC44NXw1NTIuMjQ=)'>
-<polygon points='63.02,518.26 114.51,518.26 114.51,501.57 63.02,501.57 ' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
-<line x1='63.02' y1='512.24' x2='114.51' y2='512.24' style='stroke-width: 2.25; stroke-linecap: butt;' />
-<line x1='88.76' y1='523.73' x2='88.76' y2='518.26' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
-<line x1='88.76' y1='480.54' x2='88.76' y2='501.57' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
-<line x1='75.89' y1='523.73' x2='101.64' y2='523.73' style='stroke-width: 0.75;' />
-<line x1='75.89' y1='480.54' x2='101.64' y2='480.54' style='stroke-width: 0.75;' />
-<polygon points='63.02,518.26 114.51,518.26 114.51,501.57 63.02,501.57 ' style='stroke-width: 0.75; fill: none;' />
-<circle cx='88.76' cy='462.31' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='88.76' cy='467.82' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<polygon points='127.38,541.83 178.86,541.83 178.86,530.12 127.38,530.12 ' style='stroke-width: 0.75; stroke: none; fill: #6F2935;' />
-<line x1='127.38' y1='536.13' x2='178.86' y2='536.13' style='stroke-width: 2.25; stroke-linecap: butt;' />
-<line x1='153.12' y1='545.42' x2='153.12' y2='541.83' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
-<line x1='153.12' y1='523.87' x2='153.12' y2='530.12' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
-<line x1='140.25' y1='545.42' x2='165.99' y2='545.42' style='stroke-width: 0.75;' />
-<line x1='140.25' y1='523.87' x2='165.99' y2='523.87' style='stroke-width: 0.75;' />
-<polygon points='127.38,541.83 178.86,541.83 178.86,530.12 127.38,530.12 ' style='stroke-width: 0.75; fill: none;' />
-<polygon points='191.73,548.51 243.21,548.51 243.21,547.22 191.73,547.22 ' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
-<line x1='191.73' y1='548.05' x2='243.21' y2='548.05' style='stroke-width: 2.25; stroke-linecap: butt;' />
-<line x1='217.47' y1='548.78' x2='217.47' y2='548.51' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
-<line x1='217.47' y1='545.55' x2='217.47' y2='547.22' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
-<line x1='204.60' y1='548.78' x2='230.34' y2='548.78' style='stroke-width: 0.75;' />
-<line x1='204.60' y1='545.55' x2='230.34' y2='545.55' style='stroke-width: 0.75;' />
-<polygon points='191.73,548.51 243.21,548.51 243.21,547.22 191.73,547.22 ' style='stroke-width: 0.75; fill: none;' />
-<polygon points='256.08,548.78 307.56,548.78 307.56,548.78 256.08,548.78 ' style='stroke-width: 0.75; stroke: none; fill: #306827;' />
-<line x1='256.08' y1='548.78' x2='307.56' y2='548.78' style='stroke-width: 2.25; stroke-linecap: butt;' />
-<line x1='281.82' y1='548.78' x2='281.82' y2='548.78' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
-<line x1='281.82' y1='548.78' x2='281.82' y2='548.78' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
-<line x1='268.95' y1='548.78' x2='294.69' y2='548.78' style='stroke-width: 0.75;' />
-<line x1='268.95' y1='548.78' x2='294.69' y2='548.78' style='stroke-width: 0.75;' />
-<polygon points='256.08,548.78 307.56,548.78 307.56,548.78 256.08,548.78 ' style='stroke-width: 0.75; fill: none;' />
-<polygon points='320.43,548.78 371.91,548.78 371.91,548.78 320.43,548.78 ' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
-<line x1='320.43' y1='548.78' x2='371.91' y2='548.78' style='stroke-width: 2.25; stroke-linecap: butt;' />
-<line x1='346.17' y1='548.78' x2='346.17' y2='548.78' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
-<line x1='346.17' y1='548.78' x2='346.17' y2='548.78' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
-<line x1='333.30' y1='548.78' x2='359.04' y2='548.78' style='stroke-width: 0.75;' />
-<line x1='333.30' y1='548.78' x2='359.04' y2='548.78' style='stroke-width: 0.75;' />
-<polygon points='320.43,548.78 371.91,548.78 371.91,548.78 320.43,548.78 ' style='stroke-width: 0.75; fill: none;' />
-</g>
-<defs>
-  <clipPath id='cpMC4wMHwzOTYuOTJ8NDU2LjAwfDU3Ni4wMA=='>
-    <rect x='0.000000000000040' y='456.00' width='396.92' height='120.00' />
-  </clipPath>
-</defs>
-<g clip-path='url(#cpMC4wMHwzOTYuOTJ8NDU2LjAwfDU3Ni4wMA==)'>
-<text transform='translate(27.56,505.55) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='21.56px' lengthAdjust='spacingAndGlyphs'>metric</text>
+<g clip-path='url(#cpMC4wMHwzOTYuOTJ8NDAwLjAwfDU3Ni4wMA==)'>
+<text transform='translate(27.56,491.80) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='21.56px' lengthAdjust='spacingAndGlyphs'>metric</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <line x1='88.76' y1='552.24' x2='346.17' y2='552.24' style='stroke-width: 0.75;' />
@@ -132,19 +125,22 @@
 <text x='217.47' y='564.60' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='4.41px' lengthAdjust='spacingAndGlyphs'>3</text>
 <text x='281.82' y='564.60' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='4.41px' lengthAdjust='spacingAndGlyphs'>4</text>
 <text x='346.17' y='564.60' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='4.41px' lengthAdjust='spacingAndGlyphs'>5</text>
-<line x1='43.72' y1='548.78' x2='43.72' y2='464.68' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='548.78' x2='38.97' y2='548.78' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='534.76' x2='38.97' y2='534.76' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='520.75' x2='38.97' y2='520.75' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='506.73' x2='38.97' y2='506.73' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='492.71' x2='38.97' y2='492.71' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='478.69' x2='38.97' y2='478.69' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='464.68' x2='38.97' y2='464.68' style='stroke-width: 0.75;' />
-<text transform='translate(37.07,548.78) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>0.0</text>
-<text transform='translate(37.07,520.75) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>1.0</text>
-<text transform='translate(37.07,492.71) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>2.0</text>
-<text transform='translate(37.07,464.68) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>3.0</text>
-<text x='217.47' y='452.20' text-anchor='middle' style='font-size: 11.52px; font-family: sans;' textLength='31.37px' lengthAdjust='spacingAndGlyphs'>Metric</text>
+<line x1='43.72' y1='547.76' x2='43.72' y2='438.90' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='547.76' x2='38.97' y2='547.76' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='529.62' x2='38.97' y2='529.62' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='511.48' x2='38.97' y2='511.48' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='493.33' x2='38.97' y2='493.33' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='475.19' x2='38.97' y2='475.19' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='457.05' x2='38.97' y2='457.05' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='438.90' x2='38.97' y2='438.90' style='stroke-width: 0.75;' />
+<text transform='translate(37.07,547.76) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text transform='translate(37.07,529.62) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text transform='translate(37.07,511.48) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text transform='translate(37.07,493.33) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>1.5</text>
+<text transform='translate(37.07,475.19) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>2.0</text>
+<text transform='translate(37.07,457.05) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>2.5</text>
+<text transform='translate(37.07,438.90) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>3.0</text>
+<text x='217.47' y='424.71' text-anchor='middle' style='font-size: 11.52px; font-family: sans;' textLength='31.37px' lengthAdjust='spacingAndGlyphs'>Metric</text>
 </g>
 <defs>
   <clipPath id='cpMzI4Ljc4fDM5MS4yMnwzOC4wMnwzNzYuMjQ='>
@@ -815,13 +811,6 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <polygon points='328.78,376.24 391.22,376.24 391.22,38.02 328.78,38.02 ' style='stroke-width: 0.75; fill: none;' />
 <text x='360.00' y='31.36' text-anchor='middle' style='font-size: 11.52px; font-family: sans;' textLength='21.14px' lengthAdjust='spacingAndGlyphs'>bins</text>
-</g>
-<defs>
-  <clipPath id='cpMzI4Ljc4fDM5MS4yMnw0MDIuODV8NDMyLjI0'>
-    <rect x='328.78' y='402.85' width='62.44' height='29.39' />
-  </clipPath>
-</defs>
-<g clip-path='url(#cpMzI4Ljc4fDM5MS4yMnw0MDIuODV8NDMyLjI0)'>
 </g>
 <defs>
   <clipPath id='cpNDAyLjYzfDcxNC4zMHwzOC4wMnwzNzYuMjQ='>

--- a/tests/testthat/_snaps/plotEpistack/plotepistack-with-bins.svg
+++ b/tests/testthat/_snaps/plotEpistack/plotepistack-with-bins.svg
@@ -62,63 +62,56 @@
 <text x='180.55' y='31.36' text-anchor='middle' style='font-size: 11.52px; font-family: sans;' textLength='31.37px' lengthAdjust='spacingAndGlyphs'>Metric</text>
 </g>
 <defs>
-  <clipPath id='cpNS43MHwzMTcuMzd8NDAyLjg1fDQzMi4yNA=='>
-    <rect x='5.70' y='402.85' width='311.67' height='29.39' />
+  <clipPath id='cpNDMuNzJ8MzkxLjIyfDQzMS4zNnw1NTIuMjQ='>
+    <rect x='43.72' y='431.36' width='347.50' height='120.88' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNS43MHwzMTcuMzd8NDAyLjg1fDQzMi4yNA==)'>
+<g clip-path='url(#cpNDMuNzJ8MzkxLjIyfDQzMS4zNnw1NTIuMjQ=)'>
+<polygon points='63.02,508.26 114.51,508.26 114.51,486.66 63.02,486.66 ' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<line x1='63.02' y1='500.47' x2='114.51' y2='500.47' style='stroke-width: 2.25; stroke-linecap: butt;' />
+<line x1='88.76' y1='515.34' x2='88.76' y2='508.26' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+<line x1='88.76' y1='459.44' x2='88.76' y2='486.66' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+<line x1='75.89' y1='515.34' x2='101.64' y2='515.34' style='stroke-width: 0.75;' />
+<line x1='75.89' y1='459.44' x2='101.64' y2='459.44' style='stroke-width: 0.75;' />
+<polygon points='63.02,508.26 114.51,508.26 114.51,486.66 63.02,486.66 ' style='stroke-width: 0.75; fill: none;' />
+<circle cx='88.76' cy='435.84' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='88.76' cy='442.97' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<polygon points='127.38,538.76 178.86,538.76 178.86,523.60 127.38,523.60 ' style='stroke-width: 0.75; stroke: none; fill: #6F2935;' />
+<line x1='127.38' y1='531.39' x2='178.86' y2='531.39' style='stroke-width: 2.25; stroke-linecap: butt;' />
+<line x1='153.12' y1='543.41' x2='153.12' y2='538.76' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+<line x1='153.12' y1='515.52' x2='153.12' y2='523.60' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+<line x1='140.25' y1='543.41' x2='165.99' y2='543.41' style='stroke-width: 0.75;' />
+<line x1='140.25' y1='515.52' x2='165.99' y2='515.52' style='stroke-width: 0.75;' />
+<polygon points='127.38,538.76 178.86,538.76 178.86,523.60 127.38,523.60 ' style='stroke-width: 0.75; fill: none;' />
+<polygon points='191.73,547.41 243.21,547.41 243.21,545.74 191.73,545.74 ' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<line x1='191.73' y1='546.82' x2='243.21' y2='546.82' style='stroke-width: 2.25; stroke-linecap: butt;' />
+<line x1='217.47' y1='547.76' x2='217.47' y2='547.41' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+<line x1='217.47' y1='543.58' x2='217.47' y2='545.74' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+<line x1='204.60' y1='547.76' x2='230.34' y2='547.76' style='stroke-width: 0.75;' />
+<line x1='204.60' y1='543.58' x2='230.34' y2='543.58' style='stroke-width: 0.75;' />
+<polygon points='191.73,547.41 243.21,547.41 243.21,545.74 191.73,545.74 ' style='stroke-width: 0.75; fill: none;' />
+<polygon points='256.08,547.76 307.56,547.76 307.56,547.76 256.08,547.76 ' style='stroke-width: 0.75; stroke: none; fill: #306827;' />
+<line x1='256.08' y1='547.76' x2='307.56' y2='547.76' style='stroke-width: 2.25; stroke-linecap: butt;' />
+<line x1='281.82' y1='547.76' x2='281.82' y2='547.76' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+<line x1='281.82' y1='547.76' x2='281.82' y2='547.76' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+<line x1='268.95' y1='547.76' x2='294.69' y2='547.76' style='stroke-width: 0.75;' />
+<line x1='268.95' y1='547.76' x2='294.69' y2='547.76' style='stroke-width: 0.75;' />
+<polygon points='256.08,547.76 307.56,547.76 307.56,547.76 256.08,547.76 ' style='stroke-width: 0.75; fill: none;' />
+<polygon points='320.43,547.76 371.91,547.76 371.91,547.76 320.43,547.76 ' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<line x1='320.43' y1='547.76' x2='371.91' y2='547.76' style='stroke-width: 2.25; stroke-linecap: butt;' />
+<line x1='346.17' y1='547.76' x2='346.17' y2='547.76' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+<line x1='346.17' y1='547.76' x2='346.17' y2='547.76' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+<line x1='333.30' y1='547.76' x2='359.04' y2='547.76' style='stroke-width: 0.75;' />
+<line x1='333.30' y1='547.76' x2='359.04' y2='547.76' style='stroke-width: 0.75;' />
+<polygon points='320.43,547.76 371.91,547.76 371.91,547.76 320.43,547.76 ' style='stroke-width: 0.75; fill: none;' />
 </g>
 <defs>
-  <clipPath id='cpNDMuNzJ8MzkxLjIyfDQ1OC44NXw1NTIuMjQ='>
-    <rect x='43.72' y='458.85' width='347.50' height='93.39' />
+  <clipPath id='cpMC4wMHwzOTYuOTJ8NDAwLjAwfDU3Ni4wMA=='>
+    <rect x='0.000000000000040' y='400.00' width='396.92' height='176.00' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNDMuNzJ8MzkxLjIyfDQ1OC44NXw1NTIuMjQ=)'>
-<polygon points='63.02,518.26 114.51,518.26 114.51,501.57 63.02,501.57 ' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
-<line x1='63.02' y1='512.24' x2='114.51' y2='512.24' style='stroke-width: 2.25; stroke-linecap: butt;' />
-<line x1='88.76' y1='523.73' x2='88.76' y2='518.26' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
-<line x1='88.76' y1='480.54' x2='88.76' y2='501.57' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
-<line x1='75.89' y1='523.73' x2='101.64' y2='523.73' style='stroke-width: 0.75;' />
-<line x1='75.89' y1='480.54' x2='101.64' y2='480.54' style='stroke-width: 0.75;' />
-<polygon points='63.02,518.26 114.51,518.26 114.51,501.57 63.02,501.57 ' style='stroke-width: 0.75; fill: none;' />
-<circle cx='88.76' cy='462.31' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='88.76' cy='467.82' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<polygon points='127.38,541.83 178.86,541.83 178.86,530.12 127.38,530.12 ' style='stroke-width: 0.75; stroke: none; fill: #6F2935;' />
-<line x1='127.38' y1='536.13' x2='178.86' y2='536.13' style='stroke-width: 2.25; stroke-linecap: butt;' />
-<line x1='153.12' y1='545.42' x2='153.12' y2='541.83' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
-<line x1='153.12' y1='523.87' x2='153.12' y2='530.12' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
-<line x1='140.25' y1='545.42' x2='165.99' y2='545.42' style='stroke-width: 0.75;' />
-<line x1='140.25' y1='523.87' x2='165.99' y2='523.87' style='stroke-width: 0.75;' />
-<polygon points='127.38,541.83 178.86,541.83 178.86,530.12 127.38,530.12 ' style='stroke-width: 0.75; fill: none;' />
-<polygon points='191.73,548.51 243.21,548.51 243.21,547.22 191.73,547.22 ' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
-<line x1='191.73' y1='548.05' x2='243.21' y2='548.05' style='stroke-width: 2.25; stroke-linecap: butt;' />
-<line x1='217.47' y1='548.78' x2='217.47' y2='548.51' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
-<line x1='217.47' y1='545.55' x2='217.47' y2='547.22' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
-<line x1='204.60' y1='548.78' x2='230.34' y2='548.78' style='stroke-width: 0.75;' />
-<line x1='204.60' y1='545.55' x2='230.34' y2='545.55' style='stroke-width: 0.75;' />
-<polygon points='191.73,548.51 243.21,548.51 243.21,547.22 191.73,547.22 ' style='stroke-width: 0.75; fill: none;' />
-<polygon points='256.08,548.78 307.56,548.78 307.56,548.78 256.08,548.78 ' style='stroke-width: 0.75; stroke: none; fill: #306827;' />
-<line x1='256.08' y1='548.78' x2='307.56' y2='548.78' style='stroke-width: 2.25; stroke-linecap: butt;' />
-<line x1='281.82' y1='548.78' x2='281.82' y2='548.78' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
-<line x1='281.82' y1='548.78' x2='281.82' y2='548.78' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
-<line x1='268.95' y1='548.78' x2='294.69' y2='548.78' style='stroke-width: 0.75;' />
-<line x1='268.95' y1='548.78' x2='294.69' y2='548.78' style='stroke-width: 0.75;' />
-<polygon points='256.08,548.78 307.56,548.78 307.56,548.78 256.08,548.78 ' style='stroke-width: 0.75; fill: none;' />
-<polygon points='320.43,548.78 371.91,548.78 371.91,548.78 320.43,548.78 ' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
-<line x1='320.43' y1='548.78' x2='371.91' y2='548.78' style='stroke-width: 2.25; stroke-linecap: butt;' />
-<line x1='346.17' y1='548.78' x2='346.17' y2='548.78' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
-<line x1='346.17' y1='548.78' x2='346.17' y2='548.78' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
-<line x1='333.30' y1='548.78' x2='359.04' y2='548.78' style='stroke-width: 0.75;' />
-<line x1='333.30' y1='548.78' x2='359.04' y2='548.78' style='stroke-width: 0.75;' />
-<polygon points='320.43,548.78 371.91,548.78 371.91,548.78 320.43,548.78 ' style='stroke-width: 0.75; fill: none;' />
-</g>
-<defs>
-  <clipPath id='cpMC4wMHwzOTYuOTJ8NDU2LjAwfDU3Ni4wMA=='>
-    <rect x='0.000000000000040' y='456.00' width='396.92' height='120.00' />
-  </clipPath>
-</defs>
-<g clip-path='url(#cpMC4wMHwzOTYuOTJ8NDU2LjAwfDU3Ni4wMA==)'>
-<text transform='translate(27.56,505.55) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='21.56px' lengthAdjust='spacingAndGlyphs'>metric</text>
+<g clip-path='url(#cpMC4wMHwzOTYuOTJ8NDAwLjAwfDU3Ni4wMA==)'>
+<text transform='translate(27.56,491.80) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='21.56px' lengthAdjust='spacingAndGlyphs'>metric</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <line x1='88.76' y1='552.24' x2='346.17' y2='552.24' style='stroke-width: 0.75;' />
@@ -132,19 +125,22 @@
 <text x='217.47' y='564.60' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='4.41px' lengthAdjust='spacingAndGlyphs'>3</text>
 <text x='281.82' y='564.60' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='4.41px' lengthAdjust='spacingAndGlyphs'>4</text>
 <text x='346.17' y='564.60' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='4.41px' lengthAdjust='spacingAndGlyphs'>5</text>
-<line x1='43.72' y1='548.78' x2='43.72' y2='464.68' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='548.78' x2='38.97' y2='548.78' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='534.76' x2='38.97' y2='534.76' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='520.75' x2='38.97' y2='520.75' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='506.73' x2='38.97' y2='506.73' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='492.71' x2='38.97' y2='492.71' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='478.69' x2='38.97' y2='478.69' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='464.68' x2='38.97' y2='464.68' style='stroke-width: 0.75;' />
-<text transform='translate(37.07,548.78) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>0.0</text>
-<text transform='translate(37.07,520.75) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>1.0</text>
-<text transform='translate(37.07,492.71) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>2.0</text>
-<text transform='translate(37.07,464.68) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>3.0</text>
-<text x='217.47' y='452.20' text-anchor='middle' style='font-size: 11.52px; font-family: sans;' textLength='31.37px' lengthAdjust='spacingAndGlyphs'>Metric</text>
+<line x1='43.72' y1='547.76' x2='43.72' y2='438.90' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='547.76' x2='38.97' y2='547.76' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='529.62' x2='38.97' y2='529.62' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='511.48' x2='38.97' y2='511.48' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='493.33' x2='38.97' y2='493.33' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='475.19' x2='38.97' y2='475.19' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='457.05' x2='38.97' y2='457.05' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='438.90' x2='38.97' y2='438.90' style='stroke-width: 0.75;' />
+<text transform='translate(37.07,547.76) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text transform='translate(37.07,529.62) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text transform='translate(37.07,511.48) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text transform='translate(37.07,493.33) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>1.5</text>
+<text transform='translate(37.07,475.19) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>2.0</text>
+<text transform='translate(37.07,457.05) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>2.5</text>
+<text transform='translate(37.07,438.90) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>3.0</text>
+<text x='217.47' y='424.71' text-anchor='middle' style='font-size: 11.52px; font-family: sans;' textLength='31.37px' lengthAdjust='spacingAndGlyphs'>Metric</text>
 </g>
 <defs>
   <clipPath id='cpMzI4Ljc4fDM5MS4yMnwzOC4wMnwzNzYuMjQ='>
@@ -815,13 +811,6 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <polygon points='328.78,376.24 391.22,376.24 391.22,38.02 328.78,38.02 ' style='stroke-width: 0.75; fill: none;' />
 <text x='360.00' y='31.36' text-anchor='middle' style='font-size: 11.52px; font-family: sans;' textLength='21.14px' lengthAdjust='spacingAndGlyphs'>bins</text>
-</g>
-<defs>
-  <clipPath id='cpMzI4Ljc4fDM5MS4yMnw0MDIuODV8NDMyLjI0'>
-    <rect x='328.78' y='402.85' width='62.44' height='29.39' />
-  </clipPath>
-</defs>
-<g clip-path='url(#cpMzI4Ljc4fDM5MS4yMnw0MDIuODV8NDMyLjI0)'>
 </g>
 <defs>
   <clipPath id='cpNDAyLjYzfDcxNC4zMHwzOC4wMnwzNzYuMjQ='>

--- a/tests/testthat/_snaps/plotEpistack/plotepistack-y-axis-title.svg
+++ b/tests/testthat/_snaps/plotEpistack/plotepistack-y-axis-title.svg
@@ -62,63 +62,56 @@
 <text x='180.55' y='31.36' text-anchor='middle' style='font-size: 11.52px; font-family: sans;' textLength='31.37px' lengthAdjust='spacingAndGlyphs'>Metric</text>
 </g>
 <defs>
-  <clipPath id='cpNS43MHwzMTcuMzd8NDAyLjg1fDQzMi4yNA=='>
-    <rect x='5.70' y='402.85' width='311.67' height='29.39' />
+  <clipPath id='cpNDMuNzJ8MzkxLjIyfDQzMS4zNnw1NTIuMjQ='>
+    <rect x='43.72' y='431.36' width='347.50' height='120.88' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNS43MHwzMTcuMzd8NDAyLjg1fDQzMi4yNA==)'>
+<g clip-path='url(#cpNDMuNzJ8MzkxLjIyfDQzMS4zNnw1NTIuMjQ=)'>
+<polygon points='63.02,508.26 114.51,508.26 114.51,486.66 63.02,486.66 ' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
+<line x1='63.02' y1='500.47' x2='114.51' y2='500.47' style='stroke-width: 2.25; stroke-linecap: butt;' />
+<line x1='88.76' y1='515.34' x2='88.76' y2='508.26' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+<line x1='88.76' y1='459.44' x2='88.76' y2='486.66' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+<line x1='75.89' y1='515.34' x2='101.64' y2='515.34' style='stroke-width: 0.75;' />
+<line x1='75.89' y1='459.44' x2='101.64' y2='459.44' style='stroke-width: 0.75;' />
+<polygon points='63.02,508.26 114.51,508.26 114.51,486.66 63.02,486.66 ' style='stroke-width: 0.75; fill: none;' />
+<circle cx='88.76' cy='435.84' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<circle cx='88.76' cy='442.97' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
+<polygon points='127.38,538.76 178.86,538.76 178.86,523.60 127.38,523.60 ' style='stroke-width: 0.75; stroke: none; fill: #6F2935;' />
+<line x1='127.38' y1='531.39' x2='178.86' y2='531.39' style='stroke-width: 2.25; stroke-linecap: butt;' />
+<line x1='153.12' y1='543.41' x2='153.12' y2='538.76' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+<line x1='153.12' y1='515.52' x2='153.12' y2='523.60' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+<line x1='140.25' y1='543.41' x2='165.99' y2='543.41' style='stroke-width: 0.75;' />
+<line x1='140.25' y1='515.52' x2='165.99' y2='515.52' style='stroke-width: 0.75;' />
+<polygon points='127.38,538.76 178.86,538.76 178.86,523.60 127.38,523.60 ' style='stroke-width: 0.75; fill: none;' />
+<polygon points='191.73,547.41 243.21,547.41 243.21,545.74 191.73,545.74 ' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
+<line x1='191.73' y1='546.82' x2='243.21' y2='546.82' style='stroke-width: 2.25; stroke-linecap: butt;' />
+<line x1='217.47' y1='547.76' x2='217.47' y2='547.41' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+<line x1='217.47' y1='543.58' x2='217.47' y2='545.74' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+<line x1='204.60' y1='547.76' x2='230.34' y2='547.76' style='stroke-width: 0.75;' />
+<line x1='204.60' y1='543.58' x2='230.34' y2='543.58' style='stroke-width: 0.75;' />
+<polygon points='191.73,547.41 243.21,547.41 243.21,545.74 191.73,545.74 ' style='stroke-width: 0.75; fill: none;' />
+<polygon points='256.08,547.76 307.56,547.76 307.56,547.76 256.08,547.76 ' style='stroke-width: 0.75; stroke: none; fill: #306827;' />
+<line x1='256.08' y1='547.76' x2='307.56' y2='547.76' style='stroke-width: 2.25; stroke-linecap: butt;' />
+<line x1='281.82' y1='547.76' x2='281.82' y2='547.76' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+<line x1='281.82' y1='547.76' x2='281.82' y2='547.76' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+<line x1='268.95' y1='547.76' x2='294.69' y2='547.76' style='stroke-width: 0.75;' />
+<line x1='268.95' y1='547.76' x2='294.69' y2='547.76' style='stroke-width: 0.75;' />
+<polygon points='256.08,547.76 307.56,547.76 307.56,547.76 256.08,547.76 ' style='stroke-width: 0.75; fill: none;' />
+<polygon points='320.43,547.76 371.91,547.76 371.91,547.76 320.43,547.76 ' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
+<line x1='320.43' y1='547.76' x2='371.91' y2='547.76' style='stroke-width: 2.25; stroke-linecap: butt;' />
+<line x1='346.17' y1='547.76' x2='346.17' y2='547.76' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+<line x1='346.17' y1='547.76' x2='346.17' y2='547.76' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
+<line x1='333.30' y1='547.76' x2='359.04' y2='547.76' style='stroke-width: 0.75;' />
+<line x1='333.30' y1='547.76' x2='359.04' y2='547.76' style='stroke-width: 0.75;' />
+<polygon points='320.43,547.76 371.91,547.76 371.91,547.76 320.43,547.76 ' style='stroke-width: 0.75; fill: none;' />
 </g>
 <defs>
-  <clipPath id='cpNDMuNzJ8MzkxLjIyfDQ1OC44NXw1NTIuMjQ='>
-    <rect x='43.72' y='458.85' width='347.50' height='93.39' />
+  <clipPath id='cpMC4wMHwzOTYuOTJ8NDAwLjAwfDU3Ni4wMA=='>
+    <rect x='0.000000000000040' y='400.00' width='396.92' height='176.00' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNDMuNzJ8MzkxLjIyfDQ1OC44NXw1NTIuMjQ=)'>
-<polygon points='63.02,518.26 114.51,518.26 114.51,501.57 63.02,501.57 ' style='stroke-width: 0.75; stroke: none; fill: #DF536B;' />
-<line x1='63.02' y1='512.24' x2='114.51' y2='512.24' style='stroke-width: 2.25; stroke-linecap: butt;' />
-<line x1='88.76' y1='523.73' x2='88.76' y2='518.26' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
-<line x1='88.76' y1='480.54' x2='88.76' y2='501.57' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
-<line x1='75.89' y1='523.73' x2='101.64' y2='523.73' style='stroke-width: 0.75;' />
-<line x1='75.89' y1='480.54' x2='101.64' y2='480.54' style='stroke-width: 0.75;' />
-<polygon points='63.02,518.26 114.51,518.26 114.51,501.57 63.02,501.57 ' style='stroke-width: 0.75; fill: none;' />
-<circle cx='88.76' cy='462.31' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<circle cx='88.76' cy='467.82' r='1.18' style='stroke-width: 0.75; fill: #000000;' />
-<polygon points='127.38,541.83 178.86,541.83 178.86,530.12 127.38,530.12 ' style='stroke-width: 0.75; stroke: none; fill: #6F2935;' />
-<line x1='127.38' y1='536.13' x2='178.86' y2='536.13' style='stroke-width: 2.25; stroke-linecap: butt;' />
-<line x1='153.12' y1='545.42' x2='153.12' y2='541.83' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
-<line x1='153.12' y1='523.87' x2='153.12' y2='530.12' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
-<line x1='140.25' y1='545.42' x2='165.99' y2='545.42' style='stroke-width: 0.75;' />
-<line x1='140.25' y1='523.87' x2='165.99' y2='523.87' style='stroke-width: 0.75;' />
-<polygon points='127.38,541.83 178.86,541.83 178.86,530.12 127.38,530.12 ' style='stroke-width: 0.75; fill: none;' />
-<polygon points='191.73,548.51 243.21,548.51 243.21,547.22 191.73,547.22 ' style='stroke-width: 0.75; stroke: none; fill: #000000;' />
-<line x1='191.73' y1='548.05' x2='243.21' y2='548.05' style='stroke-width: 2.25; stroke-linecap: butt;' />
-<line x1='217.47' y1='548.78' x2='217.47' y2='548.51' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
-<line x1='217.47' y1='545.55' x2='217.47' y2='547.22' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
-<line x1='204.60' y1='548.78' x2='230.34' y2='548.78' style='stroke-width: 0.75;' />
-<line x1='204.60' y1='545.55' x2='230.34' y2='545.55' style='stroke-width: 0.75;' />
-<polygon points='191.73,548.51 243.21,548.51 243.21,547.22 191.73,547.22 ' style='stroke-width: 0.75; fill: none;' />
-<polygon points='256.08,548.78 307.56,548.78 307.56,548.78 256.08,548.78 ' style='stroke-width: 0.75; stroke: none; fill: #306827;' />
-<line x1='256.08' y1='548.78' x2='307.56' y2='548.78' style='stroke-width: 2.25; stroke-linecap: butt;' />
-<line x1='281.82' y1='548.78' x2='281.82' y2='548.78' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
-<line x1='281.82' y1='548.78' x2='281.82' y2='548.78' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
-<line x1='268.95' y1='548.78' x2='294.69' y2='548.78' style='stroke-width: 0.75;' />
-<line x1='268.95' y1='548.78' x2='294.69' y2='548.78' style='stroke-width: 0.75;' />
-<polygon points='256.08,548.78 307.56,548.78 307.56,548.78 256.08,548.78 ' style='stroke-width: 0.75; fill: none;' />
-<polygon points='320.43,548.78 371.91,548.78 371.91,548.78 320.43,548.78 ' style='stroke-width: 0.75; stroke: none; fill: #61D04F;' />
-<line x1='320.43' y1='548.78' x2='371.91' y2='548.78' style='stroke-width: 2.25; stroke-linecap: butt;' />
-<line x1='346.17' y1='548.78' x2='346.17' y2='548.78' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
-<line x1='346.17' y1='548.78' x2='346.17' y2='548.78' style='stroke-width: 0.75; stroke-dasharray: 4.00,4.00;' />
-<line x1='333.30' y1='548.78' x2='359.04' y2='548.78' style='stroke-width: 0.75;' />
-<line x1='333.30' y1='548.78' x2='359.04' y2='548.78' style='stroke-width: 0.75;' />
-<polygon points='320.43,548.78 371.91,548.78 371.91,548.78 320.43,548.78 ' style='stroke-width: 0.75; fill: none;' />
-</g>
-<defs>
-  <clipPath id='cpMC4wMHwzOTYuOTJ8NDU2LjAwfDU3Ni4wMA=='>
-    <rect x='0.000000000000040' y='456.00' width='396.92' height='120.00' />
-  </clipPath>
-</defs>
-<g clip-path='url(#cpMC4wMHwzOTYuOTJ8NDU2LjAwfDU3Ni4wMA==)'>
-<text transform='translate(27.56,505.55) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='21.56px' lengthAdjust='spacingAndGlyphs'>metric</text>
+<g clip-path='url(#cpMC4wMHwzOTYuOTJ8NDAwLjAwfDU3Ni4wMA==)'>
+<text transform='translate(27.56,491.80) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='21.56px' lengthAdjust='spacingAndGlyphs'>metric</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <line x1='88.76' y1='552.24' x2='346.17' y2='552.24' style='stroke-width: 0.75;' />
@@ -132,19 +125,22 @@
 <text x='217.47' y='564.60' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='4.41px' lengthAdjust='spacingAndGlyphs'>3</text>
 <text x='281.82' y='564.60' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='4.41px' lengthAdjust='spacingAndGlyphs'>4</text>
 <text x='346.17' y='564.60' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='4.41px' lengthAdjust='spacingAndGlyphs'>5</text>
-<line x1='43.72' y1='548.78' x2='43.72' y2='464.68' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='548.78' x2='38.97' y2='548.78' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='534.76' x2='38.97' y2='534.76' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='520.75' x2='38.97' y2='520.75' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='506.73' x2='38.97' y2='506.73' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='492.71' x2='38.97' y2='492.71' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='478.69' x2='38.97' y2='478.69' style='stroke-width: 0.75;' />
-<line x1='43.72' y1='464.68' x2='38.97' y2='464.68' style='stroke-width: 0.75;' />
-<text transform='translate(37.07,548.78) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>0.0</text>
-<text transform='translate(37.07,520.75) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>1.0</text>
-<text transform='translate(37.07,492.71) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>2.0</text>
-<text transform='translate(37.07,464.68) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>3.0</text>
-<text x='217.47' y='452.20' text-anchor='middle' style='font-size: 11.52px; font-family: sans;' textLength='31.37px' lengthAdjust='spacingAndGlyphs'>Metric</text>
+<line x1='43.72' y1='547.76' x2='43.72' y2='438.90' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='547.76' x2='38.97' y2='547.76' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='529.62' x2='38.97' y2='529.62' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='511.48' x2='38.97' y2='511.48' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='493.33' x2='38.97' y2='493.33' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='475.19' x2='38.97' y2='475.19' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='457.05' x2='38.97' y2='457.05' style='stroke-width: 0.75;' />
+<line x1='43.72' y1='438.90' x2='38.97' y2='438.90' style='stroke-width: 0.75;' />
+<text transform='translate(37.07,547.76) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text transform='translate(37.07,529.62) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text transform='translate(37.07,511.48) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text transform='translate(37.07,493.33) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>1.5</text>
+<text transform='translate(37.07,475.19) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>2.0</text>
+<text transform='translate(37.07,457.05) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>2.5</text>
+<text transform='translate(37.07,438.90) rotate(-90)' text-anchor='middle' style='font-size: 7.92px; font-family: sans;' textLength='11.01px' lengthAdjust='spacingAndGlyphs'>3.0</text>
+<text x='217.47' y='424.71' text-anchor='middle' style='font-size: 11.52px; font-family: sans;' textLength='31.37px' lengthAdjust='spacingAndGlyphs'>Metric</text>
 </g>
 <defs>
   <clipPath id='cpMzI4Ljc4fDM5MS4yMnwzOC4wMnwzNzYuMjQ='>
@@ -815,13 +811,6 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <polygon points='328.78,376.24 391.22,376.24 391.22,38.02 328.78,38.02 ' style='stroke-width: 0.75; fill: none;' />
 <text x='360.00' y='31.36' text-anchor='middle' style='font-size: 11.52px; font-family: sans;' textLength='21.14px' lengthAdjust='spacingAndGlyphs'>bins</text>
-</g>
-<defs>
-  <clipPath id='cpMzI4Ljc4fDM5MS4yMnw0MDIuODV8NDMyLjI0'>
-    <rect x='328.78' y='402.85' width='62.44' height='29.39' />
-  </clipPath>
-</defs>
-<g clip-path='url(#cpMzI4Ljc4fDM5MS4yMnw0MDIuODV8NDMyLjI0)'>
 </g>
 <defs>
   <clipPath id='cpNDAyLjYzfDcxNC4zMHwzOC4wMnwzNzYuMjQ='>

--- a/vignettes/using_epistack.Rmd
+++ b/vignettes/using_epistack.Rmd
@@ -311,7 +311,7 @@ We then add the peak coordinates and each matrix to a
 
 ```{r ready_to_plot}
 merged_peaks <- SummarizedExperiment(
-    rowData = merged_peaks,
+    rowRanges = merged_peaks,
     assays = coverage_matrices
 )
 ```
@@ -462,7 +462,7 @@ h3k4me3stack <- normalizeToMatrix(
 )
 
 epidata <- SummarizedExperiment(
-    rowData = epidata,
+    rowRanges = epidata,
     assays = list(DNAme = methstack, H3K4me3 = h3k4me3stack)
 )
 ```


### PR DESCRIPTION
+ New parameters in `plotEpistack()`: `rel_widths` and `rel_heights`, to adjust the relative widths and heights of the panels.
+ In `plotEpistack()`, the boxMetric panel is now a bit higher.
+ `plotMetric()` now have a `ylab` parameter, exposed in `plotEpistack()`